### PR TITLE
Sentryによるエラー追跡の導入 #10

### DIFF
--- a/inuinouta/inuinouta/settings.py
+++ b/inuinouta/inuinouta/settings.py
@@ -152,8 +152,6 @@ if not DEBUG:
 db_from_env = dj_database_url.config(conn_max_age=600, ssl_require=True)
 DATABASES['default'].update(db_from_env)
 
-
-
 sentry_sdk.init(
     dsn="https://f1d191d25777475fb6eb5d10e87ec851@o497085.ingest.sentry.io/5572684",
     integrations=[DjangoIntegration()],

--- a/inuinouta/inuinouta/settings.py
+++ b/inuinouta/inuinouta/settings.py
@@ -16,16 +16,6 @@ import dj_database_url
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
-sentry_sdk.init(
-    dsn="https://f1d191d25777475fb6eb5d10e87ec851@o497085.ingest.sentry.io/5572684",
-    integrations=[DjangoIntegration()],
-    traces_sample_rate=1.0,
-
-    # If you wish to associate users to errors (assuming you are using
-    # # django.contrib.auth) you may enable sending PII data.
-    send_default_pii=True
-)
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -151,10 +141,24 @@ try:
 except ImportError:
     pass
 
+sentry_environment = "development"
+
 if not DEBUG:
     SECRET_KEY = os.environ['SECRET_KEY']
     import django_heroku
     django_heroku.settings(locals())
+    sentry_environment = "production"
 
 db_from_env = dj_database_url.config(conn_max_age=600, ssl_require=True)
 DATABASES['default'].update(db_from_env)
+
+
+
+sentry_sdk.init(
+    dsn="https://f1d191d25777475fb6eb5d10e87ec851@o497085.ingest.sentry.io/5572684",
+    integrations=[DjangoIntegration()],
+    traces_sample_rate=1.0,
+    send_default_pii=True,
+    environment=sentry_environment,
+)
+

--- a/inuinouta/inuinouta/settings.py
+++ b/inuinouta/inuinouta/settings.py
@@ -13,6 +13,19 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 import os
 import dj_database_url
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
+sentry_sdk.init(
+    dsn="https://f1d191d25777475fb6eb5d10e87ec851@o497085.ingest.sentry.io/5572684",
+    integrations=[DjangoIntegration()],
+    traces_sample_rate=1.0,
+
+    # If you wish to associate users to errors (assuming you are using
+    # # django.contrib.auth) you may enable sending PII data.
+    send_default_pii=True
+)
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/inuinouta/inuinouta/urls.py
+++ b/inuinouta/inuinouta/urls.py
@@ -16,7 +16,12 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
+
+def trigger_error(request):
+    division_by_zero = 1 / 0
+
 urlpatterns = [
+    path('sentry-debug/', trigger_error),
     path('', include('video.urls')),
     path('admin/', admin.site.urls),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ traitlets==4.3.3
 typing-extensions==3.7.4.2
 typing-inspect==0.6.0
 ua-parser==0.10.0
-urllib3==1.26.2
+urllib3==1.25.9
 user-agents==2.1
 wcwidth==0.1.9
 whitenoise==5.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.2.7
 backcall==0.1.0
-certifi==2020.4.5.1
+certifi==2020.12.5
 chardet==3.0.4
 dataclasses==0.7
 dataclasses-json==0.4.2
@@ -35,6 +35,7 @@ PyYAML==5.3.1
 requests==2.23.0
 requests-oauthlib==1.3.0
 responses==0.10.14
+sentry-sdk==0.19.5
 six==1.14.0
 sqlparse==0.3.1
 static3==0.7.0
@@ -43,7 +44,7 @@ traitlets==4.3.3
 typing-extensions==3.7.4.2
 typing-inspect==0.6.0
 ua-parser==0.10.0
-urllib3==1.25.9
+urllib3==1.26.2
 user-agents==2.1
 wcwidth==0.1.9
 whitenoise==5.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -31,6 +31,7 @@ PyYAML==5.3.1
 requests==2.23.0
 requests-oauthlib==1.3.0
 responses==0.10.14
+sentry-sdk==0.19.5
 six==1.14.0
 sqlparse==0.3.1
 static3==0.7.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 asgiref==3.2.7
 backcall==0.1.0
-certifi==2020.4.5.1
+certifi==2020.12.5
 chardet==3.0.4
 dataclasses-json==0.4.2
 decorator==4.4.2


### PR DESCRIPTION
Sentryのクライアントを導入。
開発環境と本番環境でそれぞれエラー追跡できるよう設定。