### PR TITLE
新UI向けのシリアライザ実装

### DIFF
--- a/inuinouta/video/apis.py
+++ b/inuinouta/video/apis.py
@@ -1,5 +1,10 @@
 from .models import Video, Song
-from .serializers import VideoSerializer, SongSerializer, RandomSerializer
+from .serializers import (
+    VideoListSerializer,
+    VideoDetailSerializer,
+    SongSerializer,
+    RandomSerializer,
+)
 from django.http import HttpResponse
 from rest_framework.viewsets import ReadOnlyModelViewSet
 from dynamic_rest.viewsets import WithDynamicViewSetMixin
@@ -7,7 +12,13 @@ from dynamic_rest.viewsets import WithDynamicViewSetMixin
 
 class VideoViewSet(WithDynamicViewSetMixin, ReadOnlyModelViewSet):
     queryset = Video.objects.filter(is_member_only=False)
-    serializer_class = VideoSerializer
+    serializer_class = VideoListSerializer  # デフォルトは一覧用
+
+    def get_serializer_class(self):
+        """一覧表示と詳細表示で異なるシリアライザーを使用"""
+        if self.action == "retrieve":
+            return VideoDetailSerializer
+        return VideoListSerializer
 
 
 class SongViewSet(WithDynamicViewSetMixin, ReadOnlyModelViewSet):
@@ -16,5 +27,5 @@ class SongViewSet(WithDynamicViewSetMixin, ReadOnlyModelViewSet):
 
 
 class RandomViewSet(WithDynamicViewSetMixin, ReadOnlyModelViewSet):
-    queryset = Song.objects.order_by('?').filter(video__is_member_only=False)
+    queryset = Song.objects.order_by("?").filter(video__is_member_only=False)
     serializer_class = RandomSerializer

--- a/inuinouta/video/serializers.py
+++ b/inuinouta/video/serializers.py
@@ -4,7 +4,9 @@ from dynamic_rest.serializers import DynamicModelSerializer
 from dynamic_rest.fields import DynamicRelationField
 
 
-class VideoSerializer(DynamicModelSerializer):
+class VideoBasicSerializer(DynamicModelSerializer):
+    """楽曲で使用する基本的なVideo情報のシリアライザー（循環参照回避）"""
+
     class Meta:
         model = Video
         fields = [
@@ -20,12 +22,67 @@ class VideoSerializer(DynamicModelSerializer):
         ]
 
 
+class SongBasicSerializer(DynamicModelSerializer):
+    """Video詳細で使用する基本的なSong情報のシリアライザー"""
+
+    class Meta:
+        model = Song
+        fields = ["id", "title", "artist", "is_original", "start_at", "end_at"]
+
+
+class VideoListSerializer(DynamicModelSerializer):
+    """動画一覧用のシリアライザー"""
+
+    songs_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Video
+        fields = [
+            "id",
+            "title",
+            "url",
+            "thumbnail_path",
+            "is_open",
+            "is_member_only",
+            "is_stream",
+            "unplayable",
+            "published_at",
+            "songs_count",
+        ]
+
+    def get_songs_count(self, obj):
+        return obj.song_set.count()
+
+
+class VideoDetailSerializer(DynamicModelSerializer):
+    """動画詳細用のシリアライザー（楽曲の詳細データを含む）"""
+
+    songs = DynamicRelationField(
+        "SongBasicSerializer", many=True, source="song_set", embed=True
+    )
+
+    class Meta:
+        model = Video
+        fields = [
+            "id",
+            "title",
+            "url",
+            "thumbnail_path",
+            "is_open",
+            "is_member_only",
+            "is_stream",
+            "unplayable",
+            "published_at",
+            "songs",
+        ]
+
+
 class SongSerializer(DynamicModelSerializer):
     class Meta:
         model = Song
         fields = ["video", "id", "title", "artist", "is_original", "start_at", "end_at"]
 
-    video = DynamicRelationField("VideoSerializer")
+    video = DynamicRelationField("VideoBasicSerializer", embed=True)
 
 
 class RandomSerializer(DynamicModelSerializer):
@@ -33,7 +90,7 @@ class RandomSerializer(DynamicModelSerializer):
         model = Song
         fields = ["video", "id", "title", "artist", "is_original", "start_at", "end_at"]
 
-    video = DynamicRelationField("VideoSerializer", embed=True)
+    video = DynamicRelationField("VideoBasicSerializer", embed=True)
 
 
 class PlaylistItemSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
This pull request refactors the serializers and viewsets in the `inuinouta/video` module to improve flexibility and readability, particularly by introducing separate serializers for video list and detail views, and by addressing potential circular reference issues.

### Serializer Refactoring:

* Introduced `VideoBasicSerializer` and `SongBasicSerializer` to provide simplified representations of `Video` and `Song` models, avoiding circular references. (`inuinouta/video/serializers.py`, [inuinouta/video/serializers.pyL7-R63](diffhunk://#diff-9af6e8bc9a5ca80f9243b897a48f16202b8b628e91b77f3ed05189b5b08e3b68L7-R63))
* Added `VideoListSerializer` for video list views, including a `songs_count` field to count associated songs. (`inuinouta/video/serializers.py`, [inuinouta/video/serializers.pyL7-R63](diffhunk://#diff-9af6e8bc9a5ca80f9243b897a48f16202b8b628e91b77f3ed05189b5b08e3b68L7-R63))
* Added `VideoDetailSerializer` for video detail views, embedding detailed song information using `SongBasicSerializer`. (`inuinouta/video/serializers.py`, [[1]](diffhunk://#diff-9af6e8bc9a5ca80f9243b897a48f16202b8b628e91b77f3ed05189b5b08e3b68L7-R63) [[2]](diffhunk://#diff-9af6e8bc9a5ca80f9243b897a48f16202b8b628e91b77f3ed05189b5b08e3b68R76)
* Updated `RandomSerializer` to use `VideoBasicSerializer` for the `video` field, ensuring consistency and avoiding unnecessary data exposure. (`inuinouta/video/serializers.py`, [inuinouta/video/serializers.pyL28-R93](diffhunk://#diff-9af6e8bc9a5ca80f9243b897a48f16202b8b628e91b77f3ed05189b5b08e3b68L28-R93))

### Viewset Enhancements:

* Refactored `VideoViewSet` to dynamically choose between `VideoListSerializer` and `VideoDetailSerializer` based on the action (`list` or `retrieve`). (`inuinouta/video/apis.py`, [inuinouta/video/apis.pyL2-R21](diffhunk://#diff-82e47d8839b0a5143bef9d0164f957cd6fa40739b9af8ce966f4993966b9b9d5L2-R21))
* Minor formatting change in `RandomViewSet` to improve code readability. (`inuinouta/video/apis.py`, [inuinouta/video/apis.pyL19-R30](diffhunk://#diff-82e47d8839b0a5143bef9d0164f957cd6fa40739b9af8ce966f4993966b9b9d5L19-R30))