### PR TITLE
fix: improve VideoAdmin with filter, search, and list_display fields

### DIFF
--- a/inuinouta/video/admin.py
+++ b/inuinouta/video/admin.py
@@ -14,7 +14,9 @@ class SongInline(admin.TabularInline):
 
 
 class VideoAdmin(admin.ModelAdmin):
-    list_display = ("title", "url", "number_of_songs", "published_at")
+    list_display = ("title", "url", "is_open", "is_stream", "number_of_songs", "published_at")
+    list_filter = ("is_open", "is_stream", "is_member_only", "unplayable")
+    search_fields = ("title", "id")
     ordering = ["-published_at"]
     inlines = [
         SongInline,


### PR DESCRIPTION
## 概要

Django Admin の `VideoAdmin` に絞り込み・検索・一覧表示の改善を追加します。

## 変更内容

`video/admin.py` の `VideoAdmin` に以下を追加:

| 項目 | 変更 |
|---|---|
| `list_display` | `is_open`, `is_stream` を追加 |
| `list_filter` | `is_open`, `is_stream`, `is_member_only`, `unplayable` を追加（新規） |
| `search_fields` | `title`, `id` を追加（新規） |

## 効果

- 管理画面の動画一覧で公開状態・配信種別を一目で確認できる
- サイドバーフィルタで `is_open` / `is_stream` / `is_member_only` / `unplayable` を絞り込み可能
- タイトルや ID でキーワード検索が可能