### PR TITLE
fix: collectstatic を dynamic-rest インストール後に実行し CSS 未配信を解消

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -3,3 +3,7 @@
 # requirements.txt からは除外し、--no-deps で個別インストールする。
 # 実際のコードは Django 5.x と互換性がある。
 pip install --no-deps dynamic-rest==2.3.0
+
+# Heroku buildpack の auto-collectstatic は DISABLE_COLLECTSTATIC=1 で抑制し、
+# dynamic-rest インストール後にここで実行することで ImportError を回避する。
+python inuinouta/manage.py collectstatic --noinput

--- a/inuinouta/inuinouta/settings.py
+++ b/inuinouta/inuinouta/settings.py
@@ -48,6 +48,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -55,7 +56,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
 ]
 
 ROOT_URLCONF = 'inuinouta.urls'
@@ -139,10 +139,21 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 STATIC_URL = '/static/'
 
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "static")
+    os.path.join(BASE_DIR, 'static')
 ]
 
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+
+# Django 5.x + WhiteNoise 6.x: STATICFILES_STORAGE は deprecated。STORAGES で指定する。
+# CompressedManifestStaticFilesStorage により gzip 圧縮とキャッシュバスティングを有効化する。
+STORAGES = {
+    'default': {
+        'BACKEND': 'django.core.files.storage.FileSystemStorage',
+    },
+    'staticfiles': {
+        'BACKEND': 'whitenoise.storage.CompressedManifestStaticFilesStorage',
+    },
+}
 
 try:
     from .local_settings import *


### PR DESCRIPTION
## 概要

Heroku の `collectstatic` 失敗と本番 CSS 未配信を解消する。

Closes #121

## 原因

Heroku Python buildpack の実行順序が以下の通りになっており、`collectstatic` 実行時に `dynamic-rest` が未インストールだったため `ImportError` が発生していた。

```
1. pip install -r requirements.txt  ← dynamic-rest は除外されているため入らない
2. python manage.py collectstatic   ← dynamic_rest が INSTALLED_APPS にある → ImportError で失敗
3. bin/post_compile                 ← ここで dynamic-rest をインストール（遅すぎる）
```

`DISABLE_COLLECTSTATIC=1` で deploy は通るが `staticfiles/` が空のまま → WhiteNoise が配信できる CSS を持っておらず未配信になっていた。

## 変更内容

### `bin/post_compile`

`dynamic-rest` インストール後に `collectstatic --noinput` を追加。  
`DISABLE_COLLECTSTATIC=1` は Heroku config var として維持し、buildpack の auto-collectstatic をスキップしたうえで、このスクリプト内で確実に dynamic-rest 依存が揃った状態で実行する。

### `inuinouta/inuinouta/settings.py`

- `WhiteNoiseMiddleware` を末尾から `SecurityMiddleware` 直後（2 番目）に移動（公式推奨の位置）
- `STORAGES['staticfiles']` に `CompressedManifestStaticFilesStorage` を設定  
  Django 5.x + WhiteNoise 6.x の推奨方式。gzip 圧縮とキャッシュバスティングを有効化。

## 確認済み事項（ローカル）

- `python inuinouta/manage.py collectstatic --noinput` → exit 0（455 files post-processed）
- `python inuinouta/manage.py findstatic css/pc.css` → 正常解決
- `python inuinouta/manage.py check` → 0 issues

## deploy 手順（確認事項）

1. このブランチを master にマージ
2. `DISABLE_COLLECTSTATIC=1` は **Heroku config var として維持したまま** `git push heroku master`
3. Heroku build log で `bin/post_compile` 内の `collectstatic` が成功していることを確認
4. 本番で `/static/css/pc.css` が 200 で取得できることを確認
5. トップページで CSS が適用されていることを確認