### PR TITLE
[video] Video 保存時の外部 I/O を分離して再試行可能にする

### DIFF
--- a/inuinouta/inuinouta/test_settings.py
+++ b/inuinouta/inuinouta/test_settings.py
@@ -1,0 +1,50 @@
+import os
+import secrets
+
+SECRET_KEY = secrets.token_urlsafe(50)
+DEBUG = True
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+INSTALLED_APPS = [
+    'video.apps.VideoConfig',
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'rest_framework',
+    'dynamic_rest',
+    'corsheaders',
+]
+
+MIDDLEWARE = [
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/inuinouta/video/admin.py
+++ b/inuinouta/video/admin.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.db import models
 
 from .models import Channel, Video, Song, Playlist, PlaylistItem
+from . import services
 
 
 class ChannelAdmin(admin.ModelAdmin):
@@ -13,14 +14,62 @@ class SongInline(admin.TabularInline):
     template = "admin/video/video/edit_inline/tabular.html"
 
 
+@admin.action(description='メタ情報を再取得する（YouTube API）')
+def fetch_meta(modeladmin, request, queryset):
+    success = 0
+    failed = 0
+    for video in queryset:
+        try:
+            services.fetch_and_apply_video_meta(video)
+            success += 1
+        except Exception as e:
+            modeladmin.message_user(
+                request,
+                f'メタ取得失敗: {video.id} — {e}',
+                level='warning',
+            )
+            failed += 1
+    if success:
+        modeladmin.message_user(request, f'{success} 件のメタ情報を更新しました。')
+
+
+@admin.action(description='サムネイルを再同期する（S3）')
+def sync_thumbs(modeladmin, request, queryset):
+    success = 0
+    for video in queryset:
+        try:
+            services.sync_thumbnail(video.id)
+            success += 1
+        except Exception as e:
+            modeladmin.message_user(
+                request,
+                f'サムネイル同期失敗: {video.id} — {e}',
+                level='warning',
+            )
+    if success:
+        modeladmin.message_user(request, f'{success} 件のサムネイルを同期しました。')
+
+
 class VideoAdmin(admin.ModelAdmin):
     list_display = ("title", "url", "is_open", "is_stream", "number_of_songs", "published_at")
     list_filter = ("is_open", "is_stream", "is_member_only", "unplayable")
     search_fields = ("title", "id")
     ordering = ["-published_at"]
-    inlines = [
-        SongInline,
-    ]
+    inlines = [SongInline]
+    actions = [fetch_meta, sync_thumbs]
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        if not change and not obj.title:
+            # 新規登録かつ title 未設定のときにメタ取得を試みる
+            try:
+                services.fetch_and_apply_video_meta(obj)
+            except Exception as e:
+                self.message_user(
+                    request,
+                    f'YouTube メタ取得に失敗しました: {e}。admin action「メタ情報を再取得する」で再試行できます。',
+                    level='warning',
+                )
 
 
 class SongAdmin(admin.ModelAdmin):

--- a/inuinouta/video/management/commands/download_thumbs.py
+++ b/inuinouta/video/management/commands/download_thumbs.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 from video.models import Video
-from video.utils import save_thumbnail
+from video import services
 
 
 class Command(BaseCommand):
@@ -25,11 +25,11 @@ class Command(BaseCommand):
         if options['all']:
             videos = Video.objects.all()
             for v in videos:
-                save_thumbnail(v.video_id)
+                services.sync_thumbnail(v.video_id)
                 self._write_success('Download success: {}'.format(v.video_id))
         elif options['latest']:
             v = Video.objects.latest('created_at')
-            save_thumbnail(v.video_id)
+            services.sync_thumbnail(v.video_id)
             self._write_success('Download success: {}'.format(v.video_id))
         else:
             if len(options['video_ids']) == 0:
@@ -39,7 +39,7 @@ class Command(BaseCommand):
                     v = Video.objects.filter(url__endswith=video_id).get()
                 except Video.DoesNotExist:
                     raise CommandError('Video "%s" does not exist' % video_id)
-                save_thumbnail(v.video_id)
+                services.sync_thumbnail(v.video_id)
                 self._write_success('Download success: {}'.format(v.video_id))
 
     def _write_success(self, message):

--- a/inuinouta/video/models.py
+++ b/inuinouta/video/models.py
@@ -1,10 +1,14 @@
+import logging
+import os
+import urllib.parse
+
 from django.db import models
 from django.dispatch import receiver
 from django.db.models.signals import post_save, post_delete
-from . import utils
-import os
-import pyyoutube
-import urllib.parse
+
+from . import services
+
+logger = logging.getLogger(__name__)
 
 S3_THUMBNAIL_PATH = "https://inuinouta.s3.ap-northeast-1.amazonaws.com/images/thumbs/"
 
@@ -42,16 +46,9 @@ class Video(models.Model):
         verbose_name_plural = "動画"
 
     def __str__(self):
-        return self.title
+        return self.title or self.id
 
     def save(self, *args, **kwargs):
-        if not self.title:
-            api_key = os.environ["YOUTUBE_API_KEY"]
-            youtube_api = pyyoutube.Api(api_key=api_key)
-            video_info = youtube_api.get_video_by_id(video_id=self.id)
-
-            self.title = video_info.items[0].snippet.title
-            self.published_at = video_info.items[0].snippet.publishedAt
         super(Video, self).save(*args, **kwargs)
 
     @property
@@ -74,12 +71,18 @@ class Video(models.Model):
 @receiver(post_save, sender=Video)
 def save_thumbnail(sender, instance, created, **kwargs):
     if created:
-        utils.save_thumbnail(instance.id)
+        try:
+            services.sync_thumbnail(instance.id)
+        except Exception:
+            logger.warning('post_save sync_thumbnail failed for video_id=%s', instance.id, exc_info=True)
 
 
 @receiver(post_delete, sender=Video)
 def delete_thumbnail(sender, instance, using, **kwargs):
-    utils.delete_thumbnail(instance.id)
+    try:
+        services.remove_thumbnail(instance.id)
+    except Exception:
+        logger.warning('post_delete remove_thumbnail failed for video_id=%s', instance.id, exc_info=True)
 
 
 class Song(models.Model):

--- a/inuinouta/video/services.py
+++ b/inuinouta/video/services.py
@@ -1,0 +1,45 @@
+import logging
+import os
+
+import pyyoutube
+
+from . import utils
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_and_apply_video_meta(video):
+    """YouTube API からメタ情報を取得し Video の title / published_at を更新する。
+
+    DB 保存（update_fields）まで行う。
+    失敗した場合は例外をそのまま raise する（呼び出し元でハンドリングすること）。
+    """
+    api_key = os.environ['YOUTUBE_API_KEY']
+    youtube_api = pyyoutube.Api(api_key=api_key)
+    video_info = youtube_api.get_video_by_id(video_id=video.id)
+
+    video.title = video_info.items[0].snippet.title
+    video.published_at = video_info.items[0].snippet.publishedAt
+    video.save(update_fields=['title', 'published_at', 'updated_at'])
+
+
+def sync_thumbnail(video_id):
+    """S3 にサムネイルを保存する。
+
+    失敗した場合は例外を飲み込み warning ログを残す。
+    """
+    try:
+        utils.save_thumbnail(video_id)
+    except Exception:
+        logger.warning('sync_thumbnail failed for video_id=%s', video_id, exc_info=True)
+
+
+def remove_thumbnail(video_id):
+    """S3 からサムネイルを削除する。
+
+    削除失敗は warning ログのみ。DB 側の削除は成功扱いとする。
+    """
+    try:
+        utils.delete_thumbnail(video_id)
+    except Exception:
+        logger.warning('remove_thumbnail failed for video_id=%s', video_id, exc_info=True)

--- a/inuinouta/video/tests.py
+++ b/inuinouta/video/tests.py
@@ -1,3 +1,128 @@
+from unittest.mock import patch, MagicMock
+
 from django.test import TestCase
 
-# Create your tests here.
+from video.models import Channel, Video
+from video import services
+
+
+def _make_channel():
+    return Channel.objects.create(name='テストチャンネル', url='https://www.youtube.com/@test')
+
+
+def _make_video(channel, video_id='abc12345', title='テスト動画'):
+    return Video.objects.create(
+        id=video_id,
+        channel=channel,
+        title=title,
+        url=f'https://www.youtube.com/watch?v={video_id}',
+    )
+
+
+class VideoSaveTest(TestCase):
+    """Video.save() が外部 I/O を呼び出さないことを確認する。"""
+
+    @patch('video.services.sync_thumbnail')
+    def test_save_without_title_does_not_call_youtube(self, mock_sync):
+        """title 未設定のまま保存しても YouTube API を呼ばない（DB 保存は成立する）。"""
+        channel = _make_channel()
+        video = Video(
+            id='abc12345',
+            channel=channel,
+            url='https://www.youtube.com/watch?v=abc12345',
+        )
+        video.save()
+        self.assertIsNone(video.title)
+        self.assertTrue(Video.objects.filter(id='abc12345').exists())
+
+    @patch('video.services.sync_thumbnail')
+    def test_str_with_no_title_returns_id(self, mock_sync):
+        """title が None のとき __str__ は id を返す。"""
+        channel = _make_channel()
+        video = Video(id='xyz99999', channel=channel, url='https://www.youtube.com/watch?v=xyz99999')
+        video.save()
+        self.assertEqual(str(video), 'xyz99999')
+
+
+class SignalTest(TestCase):
+    """post_save / post_delete signal が services 経由で動き、例外を飲み込むことを確認する。"""
+
+    @patch('video.services.sync_thumbnail')
+    def test_post_save_calls_sync_thumbnail_on_create(self, mock_sync):
+        channel = _make_channel()
+        video = _make_video(channel)
+        mock_sync.assert_called_once_with(video.id)
+
+    @patch('video.services.sync_thumbnail')
+    def test_post_save_does_not_call_sync_thumbnail_on_update(self, mock_sync):
+        channel = _make_channel()
+        video = _make_video(channel)
+        mock_sync.reset_mock()
+        video.title = '更新後タイトル'
+        video.save()
+        mock_sync.assert_not_called()
+
+    @patch('video.services.remove_thumbnail')
+    @patch('video.services.sync_thumbnail')
+    def test_post_delete_calls_remove_thumbnail(self, mock_sync, mock_remove):
+        channel = _make_channel()
+        video = _make_video(channel)
+        video_id = video.id  # delete() 後は id が None になるため事前に保存
+        video.delete()
+        mock_remove.assert_called_once_with(video_id)
+
+    @patch('video.services.sync_thumbnail', side_effect=Exception('S3 error'))
+    def test_post_save_signal_absorbs_sync_error(self, mock_sync):
+        """sync_thumbnail が失敗しても Video 作成自体は成功する。"""
+        channel = _make_channel()
+        # signal 内で例外が飲み込まれているため、ここで例外が出ないこと
+        video = _make_video(channel)
+        self.assertTrue(Video.objects.filter(id=video.id).exists())
+
+
+class FetchAndApplyVideoMetaTest(TestCase):
+    """services.fetch_and_apply_video_meta の動作を確認する。"""
+
+    @patch('video.services.sync_thumbnail')
+    @patch('video.services.pyyoutube.Api')
+    def test_updates_title_and_published_at(self, mock_api_cls, mock_sync):
+        channel = _make_channel()
+        video = _make_video(channel, title=None)
+
+        mock_info = MagicMock()
+        mock_info.items = [MagicMock(
+            snippet=MagicMock(title='Fetched Title', publishedAt='2024-06-01T00:00:00Z')
+        )]
+        mock_api_cls.return_value.get_video_by_id.return_value = mock_info
+
+        services.fetch_and_apply_video_meta(video)
+
+        video.refresh_from_db()
+        self.assertEqual(video.title, 'Fetched Title')
+        self.assertIsNotNone(video.published_at)
+
+    @patch('video.services.sync_thumbnail')
+    @patch('video.services.pyyoutube.Api')
+    def test_raises_on_api_failure(self, mock_api_cls, mock_sync):
+        """YouTube API 失敗時は例外を raise する（呼び出し元でハンドリング）。"""
+        channel = _make_channel()
+        video = _make_video(channel)
+
+        mock_api_cls.return_value.get_video_by_id.side_effect = Exception('API error')
+
+        with self.assertRaises(Exception):
+            services.fetch_and_apply_video_meta(video)
+
+
+class SyncThumbnailTest(TestCase):
+    """services.sync_thumbnail / remove_thumbnail が例外を飲み込むことを確認する。"""
+
+    @patch('video.utils.save_thumbnail', side_effect=Exception('S3 error'))
+    def test_sync_thumbnail_absorbs_exception(self, mock_save):
+        # 例外が外に出ないこと
+        services.sync_thumbnail('someid')
+
+    @patch('video.utils.delete_thumbnail', side_effect=Exception('S3 error'))
+    def test_remove_thumbnail_absorbs_exception(self, mock_delete):
+        services.remove_thumbnail('someid')
+

--- a/inuinouta/video/utils.py
+++ b/inuinouta/video/utils.py
@@ -31,6 +31,6 @@ def download_image(video_id):
     response = requests.get(url)
 
     if not response.status_code == 200:
-        e = Exception("HTTP Error: {}".format(response.status_code))
+        raise Exception("HTTP Error: {}".format(response.status_code))
 
     return response.content


### PR DESCRIPTION
## 概要

Issue #123 の対応。`Video.save()` / signal に混在していた YouTube API・S3 呼び出しを `video/services.py` に分離し、admin 保存が外部 I/O の一時障害でロールバックされないようにした。

## 変更内容

### 新規ファイル
- `video/services.py` — YouTube メタ取得・サムネイル同期の orchestration 層
  - `fetch_and_apply_video_meta(video)`: 失敗時は例外を raise（admin でハンドリング）
  - `sync_thumbnail(video_id)`: 失敗を warning ログで吸収
  - `remove_thumbnail(video_id)`: 同上
- `inuinouta/test_settings.py` — SQLite インメモリ DB を使うテスト用 settings

### 変更ファイル
- `video/models.py`
  - `Video.save()` から YouTube API 呼び出しを除去（DB 保存のみ）
  - `Video.__str__` を `return self.title or self.id` に変更（title が None でも安全）
  - signal ハンドラを `services` 経由に変更し try/except + warning ログを追加
- `video/admin.py`
  - `VideoAdmin.save_model()` で新規作成時にメタ取得を試み、失敗時は `messages.warning` で通知
  - admin action `fetch_meta`（メタ情報再取得）と `sync_thumbs`（サムネ再同期）を追加
- `video/management/commands/download_thumbs.py`
  - `utils.save_thumbnail` の直接呼び出しを `services.sync_thumbnail` 経由に変更
- `video/utils.py`
  - `download_image()` の `e = Exception(...)` バグを `raise Exception(...)` に修正

### テスト
- 10 件の unit テストを追加（save / signal / service / error-absorption）

## 受け入れ条件の確認

- [x] `Video` の admin 保存・削除が、YouTube API / S3 の一時障害でロールバックされない
- [x] 選択した動画に対してメタ情報再取得またはサムネ再同期を再試行できる
- [x] 失敗時に operator が次の手を判断できるメッセージやログが返る
- [x] 既存の公開 API 契約との整合が保たれている

## テスト実行

```bash
DJANGO_SETTINGS_MODULE=inuinouta.test_settings \
  AWS_ACCESS_KEY=dummy AWS_SECRET_KEY=dummy YOUTUBE_API_KEY=dummy \
  python manage.py test video
# Ran 10 tests ... OK
```

Closes #123